### PR TITLE
Failing rss test

### DIFF
--- a/test/js/SavingRSS.js
+++ b/test/js/SavingRSS.js
@@ -39,7 +39,16 @@ tests_xml = {
 
 jQuery(document).ready(function(){
 
-	module("GenerateRss");
+	var _username;
+	module("GenerateRss", {
+		setup: function() {
+			_username = config.options.txtUserName;
+			config.options.txtUserName = "YourName";
+		},
+		teardown: function() {
+			config.options.txtUserName = _username;
+		}
+	});
 
 	/*
 		<rss version="2.0">


### PR DESCRIPTION
I noticed one of the tests was failing in TiddlyWiki.

This was due to an environment variable (config.options.txtUserName)
This corrects this via a setup/teardown
