### PR TITLE
list macro class definition

### DIFF
--- a/js/Macros.js
+++ b/js/Macros.js
@@ -48,6 +48,7 @@ config.macros.list.handler = function(place,macroName,params,wikifier,paramStrin
 		template = config.macros.list.template;
 	}
 	var list = document.createElement("ul");
+	jQuery(list).addClass("list " + "list-" + type).data('paramString', paramString);
 	place.appendChild(list);
 	if(this[type].prompt)
 		createTiddlyElement(list,"li",null,"listTitle",this[type].prompt);
@@ -64,8 +65,8 @@ config.macros.list.handler = function(place,macroName,params,wikifier,paramStrin
 		wikify(template, li, null, tiddler);
 	}
 	if(results.length === 0 && args.emptyMessage) {
-		$(list).addClass("emptyList");
-		$("<li />").text(args.emptyMessage[0]).appendTo(list);
+		jQuery(list).addClass("emptyList");
+		jQuery("<li />").text(args.emptyMessage[0]).appendTo(list);
 	}
 };
 


### PR DESCRIPTION
second try:
added class="list list-"+type and jQuery data object "paramString" to <<list>> macro output.

Added some class info discussed in the google group.
http://groups.google.com/group/tiddlywiki/msg/9ab36790e9694046?hl=en

```
  <<list filter [tag[test]]>>
```

creates
        <ul class='list list-filter'> paramString="filter [tag[test]]"
          <li>...</li>
        </ul>
.
        <<list filter [tag[test]] emptyMessage:"no item">>
creates
        <ul class='list list-filter emptyList'>
          <li>no item</li>
        </ul>

the "paramString="filter [tag[asdf]]" is a jQuery data object.
-m
