### PR TITLE
do not dirty the story when invoking loadMissingTiddler on none file uri

### DIFF
--- a/js/Story.js
+++ b/js/Story.js
@@ -171,7 +171,10 @@ Story.prototype.loadMissingTiddler = function(title,fields,callback)
 				t.created = new Date();
 			if(!t.modified)
 				t.modified = t.created;
+			var _dirty = store.isDirty();
 			context.tiddler = store.saveTiddler(t.title,t.title,t.text,t.modifier,t.modified,t.tags,t.fields,true,t.created,t.creator);
+			if(window.location.protocol != "file:")
+				store.setDirty(_dirty);
 			autoSaveChanges();
 		} else {
 			story.refreshTiddler(context.title,null,true);


### PR DESCRIPTION
On a server load missing tiddler retrieves content that is already saved somewhere
thus it doesnt need to make the store dirty and can cause problems

(see https://github.com/TiddlySpace/tiddlyspace/issues/630)

This suggested solution checks the store state before saving in the local store and reverts to it when
not on a file uri.

Would benefit from review of someone who understands the adaptor mechanism inside out.
