### PR TITLE
added classes to list

### DIFF
--- a/js/Macros.js
+++ b/js/Macros.js
@@ -47,11 +47,11 @@ config.macros.list.handler = function(place,macroName,params,wikifier,paramStrin
 	this.refresh(list);
 };
 config.macros.list.refresh = function(list) {
-	jQuery(list).empty();
 	var paramString = jQuery(list).data("params");
 	var params = paramString.readMacroParams();
 	var args = paramString.parseParams("anon", null, null)[0];
 	var type = args.anon ? args.anon[0] : "all";
+	jQuery(list).empty().addClass("list list-" + type);
 	var template = args.template ? store.getTiddlerText(args.template[0]) : false;
 	if(!template) {
 		template = config.macros.list.template;


### PR DESCRIPTION
this reverts a change introduced and accidently removed in the commit
https://github.com/TiddlyWiki/tiddlywiki/commit/822f65386c4dbe5306729795f4962cd290a44803#diff-0

the classes "list" and "list-<list type>" are added to the list element.
