### PR TITLE
Removed sortField parameter from getMissingLinks function

### DIFF
--- a/js/TiddlyWiki.js
+++ b/js/TiddlyWiki.js
@@ -541,7 +541,7 @@ TiddlyWiki.prototype.getTiddlers = function(field,excludeTag)
 };
 
 // Return array of names of tiddlers that are referred to but not defined
-TiddlyWiki.prototype.getMissingLinks = function(sortField)
+TiddlyWiki.prototype.getMissingLinks = function()
 {
 	if(!this.tiddlersUpdated)
 		this.updateTiddlers();


### PR DESCRIPTION
Removed sortField parameter from getMissingLinks function because it isn't used.

For more info see google group discussion
http://groups.google.com/group/tiddlywikidev/browse_thread/thread/e0b85d5c51f0ba1a?hl=en
