### PR TITLE
Issue with importTiddlyWiki in differently formatted TiddlyWikis (tests provided)

### DIFF
--- a/test/js/TiddlyWiki.js
+++ b/test/js/TiddlyWiki.js
@@ -406,4 +406,36 @@ jQuery(document).ready(function(){
 		strictEqual($(storeArea).attr("id"), "storeArea", "make sure a storeArea was found");
 		strictEqual($(".tiddler", storeArea).length, 1, "there is one element with class tiddler within the element");
 	});
+
+	test("importTiddlyWiki empty store (no comments)", function() {
+		var html = ['<html><head></head><body>','<div id="storeArea"><div class="tiddler">hello</div></div>',
+			'</body></html>'].join(""); // join without newlines
+		store.importTiddlyWiki(html);
+		strictEqual($(storeArea).attr("id"), "storeArea", "make sure a storeArea was found");
+		strictEqual($(".tiddler", storeArea).length, 1, "there is one element with class tiddler within the element");
+	});
+
+	test("importTiddlyWiki empty store (upper case tags)", function() {
+		var html = ['<HTML><HEAD></HEAD><BODY>','<DIV ID="storeArea"><DIV class="tiddler">hello</DIV></DIV>',
+			'</BODY></HTML>'].join("\n"); // join with new lines in lower case
+		store.importTiddlyWiki(html);
+		strictEqual($(storeArea).attr("id"), "storeArea", "make sure a storeArea was found");
+		strictEqual($(".tiddler", storeArea).length, 1, "there is one element with class tiddler within the element");
+	});
+
+	test("importTiddlyWiki empty store (storeArea in single quotes)", function() {
+		var html = ["<HTML><HEAD></HEAD><BODY>","<DIV ID='storeArea'>",'<DIV class="tiddler">hello</DIV></DIV>',
+			'</BODY></HTML>'].join("\n"); // join with new lines in lower case
+		store.importTiddlyWiki(html);
+		strictEqual($(storeArea).attr("id"), "storeArea", "make sure a storeArea was found");
+		strictEqual($(".tiddler", storeArea).length, 1, "there is one element with class tiddler within the element");
+	});
+
+	test("importTiddlyWiki empty store (storeArea that is not a DIV)", function() {
+		var html = ["<HTML><HEAD></HEAD><BODY>","<NOSCRIPT ID='storeArea'>",'<DIV class="tiddler">hello</DIV></NOSCRIPT>',
+			'</BODY></HTML>'].join("\n"); // join with new lines in lower case
+		store.importTiddlyWiki(html);
+		strictEqual($(storeArea).attr("id"), "storeArea", "make sure a storeArea was found");
+		strictEqual($(".tiddler", storeArea).length, 1, "there is one element with class tiddler within the element");
+	});
 });


### PR DESCRIPTION
This creates failing tests and reveal a flaw in the importTiddlyWiki mechanism

In TiddlySpace where ajax is not possible due to cross domain restrictions
content is rendered into an iframe, the html of the iframe is obtained and
it is passed through the importTiddlyWiki function

When rendering content in iframes, the html rendered does not always
match the original HTML. Browsers (IE6 for instance) may upper case tag names ie. div becomes
DIV meaning that string searching cannot be relied on outside of ajax
requests.

TiddlySpace has encountered this problem:
see https://github.com/TiddlySpace/tiddlyspace/issues/675

Ideally we should be doing dom searching rather than string searching - the only thing
that should be required is an element with id storeArea

A possible solution might be 0e04e34bc37343d90dcc42accb4457646e6461b0
