### PR TITLE
prevent exception throwing when importing in chrome

### DIFF
--- a/js/Import.js
+++ b/js/Import.js
@@ -99,15 +99,19 @@ config.macros.importTiddlers.onFeedChange = function(e)
 config.macros.importTiddlers.onBrowseChange = function(e)
 {
 	var wizard = new Wizard(this);
+	var file = this.value;
 	if(this.files && this.files[0]) {
+		file = this.files[0].fileName;
 		try {
-			netscape.security.PrivilegeManager.enablePrivilege("UniversalFileRead");
+			if(typeof(netscape) !== "undefined") {
+				netscape.security.PrivilegeManager.enablePrivilege("UniversalFileRead");
+			}
 		} catch (ex) {
 			showException(ex);
 		}
 	}
 	var fileInput = wizard.getElement("txtPath");
-	fileInput.value = config.macros.importTiddlers.getURLFromLocalPath(this.value);
+	fileInput.value = config.macros.importTiddlers.getURLFromLocalPath(file);
 	var serverType = wizard.getElement("selTypes");
 	serverType.value = "file";
 	return true;


### PR DESCRIPTION
chrome now can exhibit behaviour of netscape
files is available in context, however netscape object is not defined
in Chrome. This adds a conditional to prevent throwing an exception.

Firefox and Chrome also only allow reading files from the same directory.
Also this.value now passes C:\fakepath\filename.html
rather than a real path

so we must read the filename from files if available.

this is related to issue #38
