### PR TITLE
use jsext instead of postscript

### DIFF
--- a/html/split.recipe
+++ b/html/split.recipe
@@ -2,4 +2,4 @@ template: tiddlywiki.template.html
 copyright: copyright.txt
 style: style.txt
 noscript: noscript.txt
-postscript: tiddlysaver.txt
+jsext: tiddlysaver.txt


### PR DESCRIPTION
as #69 points out the special MarkupPostBody tiddler can overwrite
this

this seems a more useful choice as jsext is currently used for adding
externalised javascript script tags for situations where tiddlywiki runs
off a server

although it may not the right choice... please suggest a better way
if there is one!
