### PR TITLE
Backstage cloak now covers whole document.

### DIFF
--- a/js/Backstage.js
+++ b/js/Backstage.js
@@ -140,7 +140,7 @@ var backstage = {
 	},
 
 	preparePanel: function() {
-		backstage.cloak.style.height = findWindowHeight() + "px";
+		backstage.cloak.style.height = findDocHeight() + "px";
 		backstage.cloak.style.display = "block";
 		jQuery(backstage.panelBody).empty();
 		return backstage.panelBody;

--- a/js/Dom.js
+++ b/js/Dom.js
@@ -101,6 +101,16 @@ function findWindowHeight()
 	return window.innerHeight || document.documentElement.clientHeight;
 }
 
+// Get the current height of the document
+function findDocHeight() {
+    var D = document;
+    return Math.max(
+        Math.max(D.body.scrollHeight, D.documentElement.scrollHeight),
+        Math.max(D.body.offsetHeight, D.documentElement.offsetHeight),
+        Math.max(D.body.clientHeight, D.documentElement.clientHeight)
+    );
+}
+
 // Get the current horizontal page scroll position
 function findScrollX()
 {

--- a/test/js/DOM.js
+++ b/test/js/DOM.js
@@ -44,6 +44,18 @@ $(document).ready(function(){
 			equals(typeof findWindowHeight(), "number", "returns a number value");
 			equals($(window).height(), findWindowHeight(), "return the current height of the display window");
 	});
+	
+	test("findDocHeight", function() {
+			expect(2);
+			equals(typeof findDocHeight(), "number", "returns a number value");
+			var maxHeight = Math.max(
+			        $(document).height(),
+			        $(window).height(),
+			        /* For opera: */
+			        document.documentElement.clientHeight
+			    );
+			equals(maxHeight, findDocHeight(), "return the current height of the document");
+	});
 
 	test("findWindowWidth", function() {
 			expect(1);


### PR DESCRIPTION
Previously the it only covered the height of the window regardless of how large the backstage popup was, creating an inconsistent and confusing interface.
