### PR TITLE
Change httpReq to not send x-requested-with header.

### DIFF
--- a/js/Http.js
+++ b/js/Http.js
@@ -51,7 +51,6 @@ function httpReq(type,url,callback,params,headers,data,contentType,username,pass
 			var i;
 			for(i in headers)
 				xhr.setRequestHeader(i,headers[i]);
-			xhr.setRequestHeader("X-Requested-With", "TiddlyWiki " + formatVersion());
 		}
 	};
 


### PR DESCRIPTION
See http://groups.google.com/group/tiddlyspace/browse_frm/thread/daf78f5ec863b5cb for details.

The gist is that in some browsers, when TiddlyWiki attempts to make an http request, if there are headers that are not within the "simple" set, then CORS is engaged and the browser will do a pre-flight check for what would otherwise have been a simple GET request.

Since the x-request-with thing is probably not that useful, I'm suggesting removing it to avoid spurious CORS requests.
