### PR TITLE
Make slices in the table notation "international"

### DIFF
--- a/js/TiddlyWiki.js
+++ b/js/TiddlyWiki.js
@@ -170,7 +170,7 @@ TiddlyWiki.prototype.getRecursiveTiddlerText = function(title,defaultText,depth)
 };
 
 //TiddlyWiki.prototype.slicesRE = /(?:^([\'\/]{0,2})~?([\.\w]+)\:\1[\t\x20]*([^\n]+)[\t\x20]*$)|(?:^\|([\'\/]{0,2})~?([\.\w]+)\:?\4\|[\t\x20]*([^\n]+)[\t\x20]*\|$)/gm;
-TiddlyWiki.prototype.slicesRE = /(?:^([\'\/]{0,2})~?([\.\w]+)\:\1[\t\x20]*([^\n]+)[\t\x20]*$)|(?:^\|\x20?([\'\/]{0,2})~?([^\|\s\:\~\'\/]|(?:[^\|\s~\'\/][^\|\n\f\r]*[^\|\s\:\'\/]))\:?\4[\x20\t]*\|[\t\x20]*([^\n]+)[\t\x20]*\|$)/gm;
+TiddlyWiki.prototype.slicesRE = /(?:^([\'\/]{0,2})~?([\.\w]+)\:\1[\t\x20]*([^\n]+)[\t\x20]*$)|(?:^\|\x20?([\'\/]{0,2})~?([^\|\s\:\~\'\/]|(?:[^\|\s~\'\/][^\|\n\f\r]*[^\|\s\:\'\/]))\:?\4[\x20\t]*\|[\t\x20]*([^\n\t\x20](?:[^\n]*[^\n\t\x20])?)[\t\x20]*\|$)/gm;
 // @internal
 TiddlyWiki.prototype.calcAllSlices = function(title)
 {


### PR DESCRIPTION
Currently, names of slices can only consist of latin letters without spaces: [.\w]+

This is somewhat inconvenient, sometimes one needs to make and then aggregate slices with names, say, in cyrillics.

For more details about the proposed slicesRe see [1];
here, other space symbols are also forbidden: \f, \r, \t
(not sure about the first two, this is to avoid confusion with \n, but they can be permitted if needed;
the \t is for another novelty - the \t\* part after :? allows to align slice tables visually in the edit mode, see below).

|name       |value|
|anotherName    |anotherValue|

[1] https://groups.google.com/forum/?hl=en.&fromgroups=#!topic/tiddlywikidev/yFNObuerUw8
