### PR TITLE
fix IE version detection

### DIFF
--- a/js/ConfigBrowser.js
+++ b/js/ConfigBrowser.js
@@ -3,7 +3,7 @@ config.userAgent = navigator.userAgent.toLowerCase();
 config.browser = {
 	isIE: config.userAgent.indexOf("msie") != -1 && config.userAgent.indexOf("opera") == -1,
 	isGecko: navigator.product == "Gecko" && config.userAgent.indexOf("WebKit") == -1,
-	ieVersion: /MSIE (\d.\d)/i.exec(config.userAgent), // config.browser.ieVersion[1], if it exists, will be the IE version string, eg "6.0"
+	ieVersion: /MSIE (\d{1,2}.\d)/i.exec(config.userAgent), // config.browser.ieVersion[1], if it exists, will be the IE version string, eg "6.0"
 	isSafari: config.userAgent.indexOf("applewebkit") != -1,
 	isBadSafari: !((new RegExp("[\u0150\u0170]","g")).test("\u0150")),
 	firefoxDate: /gecko\/(\d{8})/i.exec(config.userAgent), // config.browser.firefoxDate[1], if it exists, will be Firefox release date as "YYYYMMDD"


### PR DESCRIPTION
config.browser.ieVersion now recognizes 2-digit version #s (i.e.,
"10.0")
