### PR TITLE
improve messaging/interaction for fallback (download/manual) file saving

### DIFF
--- a/js/FileSystem.js
+++ b/js/FileSystem.js
@@ -268,22 +268,18 @@ function javaLoadFile(filePath)
 function HTML5DownloadSaveFile(filePath,content)
 {
 	if(document.createElement("a").download !== undefined) {
-		try {
-			var slashpos=filePath.lastIndexOf("/");
-			if (slashpos==-1) slashpos=filePath.lastIndexOf("\\"); 
-			var filename=filePath.substr(slashpos+1);
-			var uri = "data:text/html," + encodeURIComponent(content);
-			var link = document.createElement("a");
-			link.setAttribute("target","_blank");
-			link.setAttribute("href",uri);
-			link.setAttribute("download",filename);
-			document.body.appendChild(link); link.click(); document.body.removeChild(link);
-			return true;
-		} catch(ex) {
-			//# alert("Exception while attempting to save\n\n" + ex);
-			return true;
-		}
-
+		config.saveByDownload=true;
+		var slashpos=filePath.lastIndexOf("/");
+		if (slashpos==-1) slashpos=filePath.lastIndexOf("\\"); 
+		var filename=filePath.substr(slashpos+1);
+		var uri = "data:text/html," + encodeURIComponent(content);
+		var link = document.createElement("a");
+		link.setAttribute("target","_blank");
+		link.setAttribute("href",uri);
+		link.setAttribute("download",filename);
+		document.body.appendChild(link); link.click(); document.body.removeChild(link);
+		displayMessage(config.messages.mainDownload,uri);
+		return true;
 	}
 	return null;
 }
@@ -291,11 +287,12 @@ function HTML5DownloadSaveFile(filePath,content)
 // Returns null if it can't do it, false if there's an error, true if it saved OK
 function manualSaveFile(filePath,content)
 {
-	// QUICK FALLBACK for showing a link to data: URI
+	// FALLBACK for showing a link to data: URI
+	config.saveByDownload=true;
 	var slashpos=filePath.lastIndexOf("/");
 	if (slashpos==-1) slashpos=filePath.lastIndexOf("\\"); 
 	var filename=filePath.substr(slashpos+1);
 	var uri = "data:text/html," + encodeURIComponent(content);
-	displayMessage("RIGHT CLICK HERE TO SAVE "+filename+": ",uri);
+	displayMessage(config.messages.mainDownloadManual,uri);
 	return true;
 }

--- a/js/Lingo.js
+++ b/js/Lingo.js
@@ -61,6 +61,8 @@ merge(config.messages,{
 	emptySaved: "Empty template saved",
 	emptyFailed: "Failed to save empty template file",
 	mainSaved: "Main TiddlyWiki file saved",
+	mainDownload: "Downloading/saving main TiddlyWiki file",
+	mainDownloadManual: "RIGHT CLICK HERE to download/save main TiddlyWiki file",
 	mainFailed: "Failed to save main TiddlyWiki file. Your changes have not been saved",
 	macroError: "Error in macro <<%0>>",
 	macroErrorDetails: "Error while executing macro <<%0>>:\n%1",

--- a/js/Saving.js
+++ b/js/Saving.js
@@ -168,14 +168,16 @@ function saveChanges(onlyIfDirty,tiddlers)
 		alert(msg.invalidFileError.format([localPath]));
 		return;
 	}
+	var co=config.options; //# abbreviation
+	config.saveByDownload=false;
 	saveMain(localPath,original,posDiv);
-	if(config.options.chkSaveBackups)
+	if(co.chkSaveBackups && !config.saveByDownload)
 		saveBackup(localPath,original);
-	if(config.options.chkSaveEmptyTemplate)
+	if(co.chkSaveEmptyTemplate && !config.saveByDownload)
 		saveEmpty(localPath,original,posDiv);
-	if(config.options.chkGenerateAnRssFeed && saveRss instanceof Function)
+	if(co.chkGenerateAnRssFeed && saveRss instanceof Function && !config.saveByDownload)
 		saveRss(localPath);
-	if(config.options.chkDisplayInstrumentation)
+	if(co.chkDisplayInstrumentation)
 		displayMessage("saveChanges " + (new Date()-t0) + " ms");
 }
 
@@ -190,7 +192,8 @@ function saveMain(localPath,original,posDiv)
 		showException(ex);
 	}
 	if(save) {
-		displayMessage(config.messages.mainSaved,"file://" + localPath);
+		if (!config.saveByDownload) //# set by HTML5DownloadSaveFile() or manualSaveFile()
+			displayMessage(config.messages.mainSaved,"file://" + localPath);
 		store.setDirty(false);
 	} else {
 		alert(config.messages.mainFailed);


### PR DESCRIPTION
set 'config.saveByDownload' flag when using download/manual fallback for
file saving.   Added specific messages for HTML5DownloadSaveFile() and
manualSaveFile().  When config.saveByDownload is set, suppress standard
"mainSaved" message  and also bypass saving of backup, XML, and 'empty'
files (i.e., only save main file)
