### PR TITLE
Critical fix to get TiddlyWiki 2.8.0 working on IE 6 and 7

### DIFF
--- a/js/Saving.js
+++ b/js/Saving.js
@@ -107,9 +107,15 @@ function recreateOriginal()
 {
 	// construct doctype
 	var t=document.doctype;
-	var content = "<!DOCTYPE "+t.name;
-	if      (t.publicId)		content+=' PUBLIC "'+t.publicId+'"';
-	else if (t.systemId)		content+=' SYSTEM "'+t.systemId+'"';
+	var content;
+	if (t) {
+		content = "<!DOCTYPE "+t.name;
+		if      (t.publicId)		content+=' PUBLIC "'+t.publicId+'"';
+		else if (t.systemId)		content+=' SYSTEM "'+t.systemId+'"';
+	} else {
+		// IE 6 and 7 provide no result on document.doctype, so fake it
+		content = "<!DOCTYPE html ";
+	}
 	content+=' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"';
 	content+='>\n';
 


### PR DESCRIPTION
In IE6 and 7 `document.doctype` does not return an object.

(Actually it appears 8 is involved as well:  In Internet Explorer 8 and
earlier, this property returns null for HTML and XHTML documents, and
will only work for XML documents.)

Thus many of the lines in Saving.js:recreateOriginal throw
an error in those browsers, stopping TiddlyWiki from booting.

A workaround appears to be faking (with reasonable data) the
content in recreateOriginal when there is no doctype. This
appears to bring back a working tiddlywiki in IE6 and 7.

However given that recreateOriginal appears to be required
for the HTML5 saving and that stuff doesn't work on ie6 and 7
it may be better just to circumvent this branch of code
entirely. I didn't explore that option as my ability to do any
IE-based testing is rather curtailed (I've used up all my free mi utes

For reference:
- the original empty.html demonstrates the error
  http://tiddlywiki.com/empty.html
- an empty.html with a version of the attached fix
  (and some alerts)
  http://burningchrome.com/empty.html
- A MTC that shows the problem at
  http://burningchrome.com/simple.html

There's anecdotal evidence that this problem is also present in
later versions of IE depending on the compatibility mode of the
brower.

This problem is causing the AMBIT project on TiddlySpace to
not work. They reported the bug. For them it is rather critical.
