### PR TITLE
fixed missing tab — tids may be empty but existing

### DIFF
--- a/js/TiddlyWiki.js
+++ b/js/TiddlyWiki.js
@@ -571,7 +571,7 @@ TiddlyWiki.prototype.getMissingLinks = function()
 		var n;
 		for(n=0; n<tiddler.links.length;n++) {
 			var link = tiddler.links[n];
-			if(this.getTiddlerText(link,null) == null && !this.isShadowTiddler(link) && !config.macros[link])
+			if (null == this.getTiddler(link) && !this.isShadowTiddler(link) && !config.macros[link])
 				results.pushUnique(link);
 		}
 	});


### PR DESCRIPTION
some tags may be created as tids, yet not have any content — so, they're not missing
