### PR TITLE
Fix TiddlySaver 1

### DIFF
--- a/java/src/TiddlySaver.java
+++ b/java/src/TiddlySaver.java
@@ -210,7 +210,7 @@ public class TiddlySaver extends java.applet.Applet {
     }
 
 
-    public static boolean isNullOrEmpty(String s) {
+    private static boolean isNullOrEmpty(String s) {
         return s == null || "".equals(s.trim());
     }
 


### PR DESCRIPTION
This allows TW Classic to load/save with TiddlySaver by changing the 'restrictToSameDirectory' flag. I removed all the javadoc updates from my last attempt (now deleted) to make the changes more obvious. Will update javadoc when/if I rewrite the restriction code; not sure it's needed as a good policy file ensures this, but will revisit later.

Tested with TW Classic (a 2.7.0 prerelease I had around) with the following policy file (assuming Windows location `C:\TW`:

```
grant codeBase "file:C:/TW/TiddlySaver.jar" {
    permission java.io.FilePermission "<<ALL FILES>>", "read";
    permission java.io.FilePermission "C:${/}TW${/}*", "write";
};
```
