### PR TITLE
allows to use macro references in macro parameters

### DIFF
--- a/js/Strings.js
+++ b/js/Strings.js
@@ -159,7 +159,8 @@ String.prototype.parseParams = function(defaultName,defaultValue,allowEval,noNam
 	} while(match);
 	// Summarise parameters into first element
 	var t;
-	for(t=1; t<r.length; t++) {
+	for (t = 1; t < r.length; t++) {
+	    r[t].value = r[t].value.replace(/\>\+\>/mg, '>>');
 		if(r[0][r[t].name])
 			r[0][r[t].name].push(r[t].value);
 		else
@@ -176,7 +177,7 @@ String.prototype.readMacroParams = function(notAllowEval)
 	var p = this.parseParams("list",null,!notAllowEval,true);
 	var t,n = [];
 	for(t=1; t<p.length; t++)
-		n.push(p[t].value);
+	    n.push(p[t].value.replace(/\>\+\>/mg, '>>'));
 	return n;
 };
 


### PR DESCRIPTION
Using the following syntax this change allows to pass macro syntax
within macro parameters as follows...

```
<<tiddler Template with: '<<tag Foo>+>'>>
```

All '>+>' are be replaced with '>>' BEFORE further processing.

In fact, this will work for any macro, e.g.

```
<<foo "<<bar>+>" >>
```
