### PR TITLE
Revert "fixed missing tab — tids may be empty but existing"

### DIFF
--- a/js/TiddlyWiki.js
+++ b/js/TiddlyWiki.js
@@ -571,7 +571,7 @@ TiddlyWiki.prototype.getMissingLinks = function()
 		var n;
 		for(n=0; n<tiddler.links.length;n++) {
 			var link = tiddler.links[n];
-			if (null == this.getTiddler(link) && !this.isShadowTiddler(link) && !config.macros[link])
+			if(this.getTiddlerText(link,null) == null && !this.isShadowTiddler(link) && !config.macros[link])
 				results.pushUnique(link);
 		}
 	});


### PR DESCRIPTION
Reverts TiddlyWiki/tiddlywiki#149

After further examination, this change is not correct, as it doesn't allow for section references in transclusions (e.g., "<<tiddler TiddlerName##section>>"), which would then be reported as missing.   Also, if a tiddler exists, but is empty of content, then the tiddler.text property should NOT be null, but rather a blank text string  (e.g., "").  The only way for a tiddler to have a null text property is if it was improperly created or updated by a plugin that passes a null value, rather than a blank text string when using store.saveTiddler(...).
