### PR TITLE
Fixed error replaced this by tags variable

### DIFF
--- a/js/Story.js
+++ b/js/Story.js
@@ -408,17 +408,18 @@ Story.prototype.blurTiddler = function(title)
 //#  tag - value of field, without any [[brackets]]
 //#  mode - +1 to add the tag, -1 to remove it, 0 to toggle it
 //#  field - name of field (eg "tags")
+//# 2023-10-23 Okido: this is not the correct variable, it must be tags
 Story.prototype.setTiddlerField = function(title, tag, mode, field)
 {
 	var editor = this.getTiddlerField(title, field);
 	var tags = editor.value.readBracketedList();
 
-	var i = this.indexOf(tag);
+	var i = tags.indexOf(tag);
 	if(mode == 0) mode = (i == -1) ? +1 : -1;
 	if(mode == +1) {
-		if(i == -1) this.push(tag);
+		if(i == -1) tags.push(tag);
 	} else if(mode == -1) {
-		if(i != -1) this.splice(i, 1);
+		if(i != -1) tags.splice(i, 1);
 	}
 
 	editor.value = String.encodeTiddlyLinkList(tags);

--- a/js/Story.js
+++ b/js/Story.js
@@ -408,7 +408,6 @@ Story.prototype.blurTiddler = function(title)
 //#  tag - value of field, without any [[brackets]]
 //#  mode - +1 to add the tag, -1 to remove it, 0 to toggle it
 //#  field - name of field (eg "tags")
-//# 2023-10-23 Okido: this is not the correct variable, it must be tags
 Story.prototype.setTiddlerField = function(title, tag, mode, field)
 {
 	var editor = this.getTiddlerField(title, field);

--- a/js/Version.js
+++ b/js/Version.js
@@ -1,1 +1,1 @@
-var version = {title: "TiddlyWiki", major: 2, minor: 9, revision: 5, beta: 2, date: new Date("October 30, 2023"), extensions: {}};
+var version = {title: "TiddlyWiki", major: 2, minor: 9, revision: 4, nightly: 2, date: new Date("October 30, 2023"), extensions: {}};

--- a/js/Version.js
+++ b/js/Version.js
@@ -1,1 +1,1 @@
-var version = {title: "TiddlyWiki", major: 2, minor: 9, revision: 4, date: new Date("May 11, 2023"), extensions: {}};
+var version = {title: "TiddlyWiki", major: 2, minor: 9, revision: 5, beta: 2, date: new Date("October 30, 2023"), extensions: {}};


### PR DESCRIPTION
IntelliTaggerPlugin from Abego v1.0.2 (2007-07-25) does not work, it throws an error in the console: "this.indexOf is not a function", wrong variable is used in Story.prototype.setTiddlerField, this must be tags, updated versioning to 2.9.5 beta 2.

Okido