### PR TITLE
css: fix missing color palette reference

### DIFF
--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -137,8 +137,8 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 
 .highlight, .marked {background:[[ColorPalette::SecondaryLight]];}
 
-.editor input {border:1px solid [[ColorPalette::PrimaryMid]];}
-.editor textarea {border:1px solid [[ColorPalette::PrimaryMid]]; width:100%;}
+.editor input {border:1px solid [[ColorPalette::PrimaryMid]]; background:[[ColorPalette::Background]]; color:[[ColorPalette::Foreground]];}
+.editor textarea {border:1px solid [[ColorPalette::PrimaryMid]]; width:100%; background:[[ColorPalette::Background]]; color:[[ColorPalette::Foreground]];}
 .editorFooter {color:[[ColorPalette::TertiaryMid]];}
 .readOnly {background:[[ColorPalette::TertiaryPale]];}
 

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -26,7 +26,7 @@ ol ol ol ol ol {list-style-type:lower-alpha;}
 ol ol ol ol ol ol {list-style-type:lower-roman;}
 ol ol ol ol ol ol ol {list-style-type:decimal;}
 
-.txtOptionInput {width:11em;}
+.txtOptionInput {width:11em; background:[[ColorPalette::Background]]; color:[[ColorPalette::Foreground]];}
 
 #contentWrapper .chkOptionInput {border:0;}
 


### PR DESCRIPTION
Some color in ColorPalette do not appear in some css fragments where they should do. It doesn't have any consequence if you use the original ColorPalette. However, if you try to make your own ColorPalette, e.g., your own dark mode (other than Yakov Litvin's DarkModePlugin), you'll find some colors don't change as you expected.

1. Here's a snapshot of what's my own dark mode color palette will exhibit in view mode, which is **as expected**:
![20240125-114427](https://github.com/TiddlyWiki/TiddlyWikiClassic/assets/13349414/dec458b5-ab38-4b05-9ad6-11bf198b110e)
1. Here in edit mode, which is **not as expected**:
![20240125-114441](https://github.com/TiddlyWiki/TiddlyWikiClassic/assets/13349414/172f4fec-1d23-496f-8f48-3075fb32bf1d)
1. Here it appears **as what we want** after the fix:
![20240125-114454](https://github.com/TiddlyWiki/TiddlyWikiClassic/assets/13349414/4d9f5893-637c-4212-a45c-4a79b3c9e72b)
