### PR TITLE
docs: remove the unused favicon.ico.tid

### DIFF
--- a/content/favicon.ico.tid
+++ b/content/favicon.ico.tid
@@ -1,8 +1,0 @@
-created: 20110211111500000
-creator: jon
-modified: 20110211111500000
-modifier: jon
-title: favicon.ico
-type: image/x-icon
-
-AAABAAEAEBAAAAAAGABoAwAAFgAAACgAAAAQAAAAIAAAAAEAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD////////////////////////////////////////////////a2tra2tra2tra2tr///////////+fn5+fn5+fn5+fn5+fn5+fn5/////////////a2tra2tra2tra2tr////MzMz////////////////////////////////////////a2tra2tra2tra2tr///////////+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5/////a2tra2tra2tra2tr////MzMz////////////////////////////////////////a2tra2tra2tra2tr///////////+fn5+fn5+fn5+fn5/////////////////////a2tra2tra2tra2tr////MzMz///+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5/////a2tra2tra2tra2tr///////////+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5/////////////////////////MzMz////////////////////////////////////////a2tra2tra2tra2tr///////////+fn5+fn5+fn5+fn5+fn5+fn5+fn5/////////////////////////////MzMz///+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5/////a2tra2tra2tra2tr////////////////////////////////////////////////////////////////ETQPETQPETQPETQPETQPETQPETQPETQPETQPETQPETQPETQPETQPETQPETQPETQPVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfVXgfmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwvmbwv2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw/2fw8AAOLpAADg6QAAf18AAP//AAD//wAA//8AAP//AAD//wAAAIAAAP//AAD/fwAA//8AAACAAAD//wAA//8AAOHp

--- a/content/split.recipe
+++ b/content/split.recipe
@@ -407,8 +407,6 @@ tiddler: closeAll%20macro.tid
 
 tiddler: example.tid
 
-tiddler: favicon.ico.tid
-
 tiddler: list%20macro.tid
 
 tiddler: luakit.tid


### PR DESCRIPTION
This small PR is to test both that the tiddler is not used (I'm almost certain of it) and to test [the submodule fix](https://github.com/TiddlyWiki/tiddlywiki.github.com/commit/c8ed9c6cecd9cb8165f17b5e327f14ca9e1339c9) in the github pages repo